### PR TITLE
Add package for Bromix.MudBlazor.MaterialDesignIcons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ More Components and Services for the MudBlazor ecosystem authored by the Communi
 - [MudBlazor.Markdown](https://github.com/MyNihongo/MudBlazor.Markdown) A markdown component for MudBlazor
 - [MT.MudBlazor.Extensions](https://github.com/Medtelligent/MT.MudBlazor.Extensions) A DrawerService that allows opening Drawers like Dialogs 
 - [CodeGator.Forms.MudBlazor](https://github.com/CodeGator/CG.Blazor.Forms._MudBlazor) Form model attributes which allow building the form automatically.
+- [Bromix.MudBlazor.MaterialDesignIcons](https://github.com/bromix/Bromix.MudBlazor.MaterialDesignIcons) A package for Material Design Icons based on [https://materialdesignicons.com](https://materialdesignicons.com)


### PR DESCRIPTION
I've created a script that convers the SVG files into a .NET package so we can use it directly in MudBlazor.